### PR TITLE
feat: don't panic unbolding feature

### DIFF
--- a/src/client/containers/ContextMenuOptions.tsx
+++ b/src/client/containers/ContextMenuOptions.tsx
@@ -1,11 +1,17 @@
 import React, { useContext } from 'react'
-import { ArrowUp, Download, Star, Trash, X, Edit2, Clipboard } from 'react-feather'
+import { ArrowUp, Download, Star, Trash, X, Edit2, Clipboard, XCircle } from 'react-feather'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { LabelText } from '@resources/LabelText'
 import { TestID } from '@resources/TestID'
 import { ContextMenuOption } from '@/components/NoteList/ContextMenuOption'
-import { downloadNotes, isDraftNote, getShortUuid, copyToClipboard } from '@/utils/helpers'
+import {
+  downloadNotes,
+  isDraftNote,
+  getShortUuid,
+  copyToClipboard,
+  unboldNote,
+} from '@/utils/helpers'
 import {
   deleteNotes,
   toggleFavoriteNotes,
@@ -14,6 +20,7 @@ import {
   updateActiveNote,
   swapFolder,
   removeCategoryFromNotes,
+  updateNote,
 } from '@/slices/note'
 import { getCategories, getNotes } from '@/selectors'
 import { Folder, ContextMenuEnum } from '@/utils/enums'
@@ -121,7 +128,7 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
     dispatch(addCategoryToNote({ categoryId, noteId }))
   const _updateActiveNote = (noteId: string, multiSelect: boolean) =>
     dispatch(updateActiveNote({ noteId, multiSelect }))
-
+  const _updateNote = (note: NoteItem) => dispatch(updateNote(note))
   // ===========================================================================
   // Handlers
   // ===========================================================================
@@ -143,6 +150,11 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
 
     const shortNoteUuid = getShortUuid(note.id)
     copyToClipboard(`{{${shortNoteUuid}}}`)
+  }
+  const unboldNoteHandler = () => {
+    const { text: clickedNoteText } = clickedNote
+    const unboldedText = unboldNote(clickedNoteText)
+    _updateNote({ ...clickedNote, text: unboldedText })
   }
 
   return !isDraftNote(clickedNote) ? (
@@ -206,6 +218,12 @@ const NotesOptions: React.FC<NotesOptionsProps> = ({ clickedNote }) => {
         handler={(e: React.SyntheticEvent) => copyLinkedNoteMarkdownHandler(e, clickedNote)}
         icon={Clipboard}
         text={LabelText.COPY_REFERENCE_TO_NOTE}
+      />
+      <ContextMenuOption
+        dataTestID={TestID.DONT_PANIC}
+        handler={unboldNoteHandler}
+        icon={XCircle}
+        text={LabelText.DONT_PANIC}
       />
     </nav>
   ) : null

--- a/src/client/utils/helpers.ts
+++ b/src/client/utils/helpers.ts
@@ -294,3 +294,10 @@ export const getNoteBarConf = (
 export const copyToClipboard = (text: string) => {
   clipboard.writeText(text)
 }
+
+export const unboldNote = (note: string) => {
+  var unboldedText = note.replace(/\*\*([^*]*(?:\*(?!\*)[^*]*)*)\*\*/g, function (match, index) {
+    return '' + index + ''
+  })
+  return unboldedText
+}

--- a/src/resources/LabelText.ts
+++ b/src/resources/LabelText.ts
@@ -27,4 +27,5 @@ export enum LabelText {
   IMPORT_BACKUP = 'Import backup',
   TOGGLE_FAVORITE = 'Toggle favorite',
   COPY_REFERENCE_TO_NOTE = 'Copy reference to note',
+  DONT_PANIC = "Don't Panic",
 }

--- a/src/resources/TestID.ts
+++ b/src/resources/TestID.ts
@@ -55,4 +55,5 @@ export enum TestID {
   LAST_SYNCED_NOTIFICATION_SYNCING = 'last-synced-notification-syncing',
   LAST_SYNCED_NOTIFICATION_UNSAVED = 'last-synced-notification-unsaved',
   LAST_SYNCED_NOTIFICATION_DATE = 'last-synced-notification-date',
+  DONT_PANIC = 'dont-panic',
 }

--- a/tests/e2e/integration/note.test.ts
+++ b/tests/e2e/integration/note.test.ts
@@ -14,6 +14,8 @@ import {
   testIDShouldContain,
   testIDShouldNotExist,
   clickDynamicTestID,
+  getTestID,
+  getDynamicTestID,
 } from '../utils/testHelperUtils'
 import {
   assertNewNoteCreated,
@@ -41,6 +43,7 @@ import {
   holdKeyAndClickNoteAtIndex,
   trashAllNotes,
   dragAndDrop,
+  clickNoteOptionUnboldNote,
 } from '../utils/testNotesHelperUtils'
 import {
   addCategory,
@@ -538,6 +541,25 @@ describe('Manage notes test', () => {
     cy.get('[data-testid=trash]').click()
     cy.get('[data-testid=note-list]').within(() => {
       cy.get('.note-list-each').should('have.length', 1)
+    })
+  })
+
+  it('should unbold a note', () => {
+    const boldedNote = 'Sample **note** text.'
+    const unboldedNote = 'Sample note text.'
+
+    navigateToNotes()
+    clickNoteOptions()
+    testIDShouldContain(TestID.DONT_PANIC, LabelText.DONT_PANIC)
+
+    clickCreateNewNote()
+    typeNoteEditor(boldedNote)
+
+    openNoteContextMenu()
+    clickNoteOptionUnboldNote()
+
+    cy.get('.CodeMirror-code').each((element) => {
+      expect(element.text()).to.equal(unboldedNote)
     })
   })
 

--- a/tests/e2e/utils/testNotesHelperUtils.ts
+++ b/tests/e2e/utils/testNotesHelperUtils.ts
@@ -121,6 +121,10 @@ const clickNoteOptionCopyLinkedNoteMarkdown = () => {
   clickTestID(TestID.COPY_REFERENCE_TO_NOTE)
 }
 
+const clickNoteOptionUnboldNote = () => {
+  clickTestID(TestID.DONT_PANIC)
+}
+
 const clickSyncNotes = () => {
   clickTestID(TestID.TOPBAR_ACTION_SYNC_NOTES)
 }
@@ -164,6 +168,7 @@ export {
   clickNoteOptionTrash,
   clickNoteOptions,
   clickNoteOptionCopyLinkedNoteMarkdown,
+  clickNoteOptionUnboldNote,
   clickSyncNotes,
   typeNoteEditor,
   typeNoteSearch,

--- a/tests/unit/client/utils/index.test.ts
+++ b/tests/unit/client/utils/index.test.ts
@@ -1,6 +1,11 @@
 import dayjs from 'dayjs'
 
-import { getNoteTitle, getWebsiteTitle, getActiveNoteFromShortUuid } from '@/utils/helpers'
+import {
+  getNoteTitle,
+  getWebsiteTitle,
+  getActiveNoteFromShortUuid,
+  unboldNote,
+} from '@/utils/helpers'
 import { Folder } from '@/utils/enums'
 import { NoteItem, CategoryItem } from '@/types'
 
@@ -105,6 +110,18 @@ describe('Utilities', () => {
       const notes = [oneNote, otherNote]
 
       expect(getActiveNoteFromShortUuid(notes, shortActiveNoteId)).toEqual(undefined)
+    })
+  })
+  describe('removeBoldStringsFromNote', () => {
+    test(`should remove astrix from both sides of a word`, () => {
+      const boldNote = `This is your **world**. This is gonna be a **happy** little seascape.`
+      const unboldedNote = `This is your world. This is gonna be a happy little seascape.`
+      expect(unboldNote(boldNote)).toEqual(unboldedNote)
+    })
+    test(`should not remove two astrixes that aren't followed by a word and ending two astrixes`, () => {
+      const boldNote = `This is your **world. This is gonna be a happy little seascape.`
+      const unboldedNote = `This is your **world. This is gonna be a happy little seascape.`
+      expect(unboldNote(boldNote)).toEqual(unboldedNote)
     })
   })
 })


### PR DESCRIPTION
## Description
- encapsulated the unbolding function so it could be tested alone and so it could be reusable in the bottom icon row.
- Followed project conventions by adding enums to LabelText.ts and TestID.ts (rather than hard-coding text).
- Used Js functions to illustrate functionality rather than loops or recursions (since this challenge is for a JS react role :) ).
- Didn't add comment and doc since the change is fairly easy to read and code is usually good when it can be understood by itself.

### Testing

- [ ] Cypress click test has been added to the newly added UI.
- [ ] Jest test has been added to test helper function functionality.

### Suggestions
- Dev team needs to maintain the app (regarding dependencies and node versions) so that the web app is compatible withe new node versions. (E.g. Node v16)
